### PR TITLE
Adding time based rotation policy to HDFS Bolt. HAd to refactor file wri...

### DIFF
--- a/src/main/java/org/apache/storm/hdfs/bolt/format/FileNameFormat.java
+++ b/src/main/java/org/apache/storm/hdfs/bolt/format/FileNameFormat.java
@@ -18,6 +18,7 @@
 package org.apache.storm.hdfs.bolt.format;
 
 import backtype.storm.task.TopologyContext;
+import org.apache.storm.hdfs.common.format.CommonFileNameFormat;
 
 import java.io.Serializable;
 import java.util.Map;
@@ -26,17 +27,8 @@ import java.util.Map;
  * Formatter interface for determining HDFS file names.
  *
  */
-public interface FileNameFormat extends Serializable {
+public interface FileNameFormat extends CommonFileNameFormat {
 
     void prepare(Map conf, TopologyContext topologyContext);
 
-    /**
-     * Returns the filename the HdfsBolt will create.
-     * @param rotation the current file rotation number (incremented on every rotation)
-     * @param timeStamp current time in milliseconds when the rotation occurs
-     * @return
-     */
-    String getName(long rotation, long timeStamp);
-
-    String getPath();
 }

--- a/src/main/java/org/apache/storm/hdfs/bolt/format/SequenceFormat.java
+++ b/src/main/java/org/apache/storm/hdfs/bolt/format/SequenceFormat.java
@@ -2,6 +2,7 @@ package org.apache.storm.hdfs.bolt.format;
 
 import backtype.storm.tuple.Tuple;
 import org.apache.hadoop.io.Writable;
+import org.apache.storm.hdfs.common.format.CommonSequenceFormat;
 
 import java.io.Serializable;
 
@@ -9,20 +10,7 @@ import java.io.Serializable;
  * Interface for converting <code>Tuple</code> objects to HDFS sequence file key-value pairs.
  *
  */
-public interface SequenceFormat extends Serializable {
-    /**
-     * Key class used by implementation (e.g. IntWritable.class, etc.)
-     *
-     * @return
-     */
-    Class keyClass();
-
-    /**
-     * Value class used by implementation (e.g. Text.class, etc.)
-     * @return
-     */
-    Class valueClass();
-
+public interface SequenceFormat extends CommonSequenceFormat {
     /**
      * Given a tuple, return the key that should be written to the sequence file.
      *

--- a/src/main/java/org/apache/storm/hdfs/bolt/rotation/TimeBasedRotationPolicy.java
+++ b/src/main/java/org/apache/storm/hdfs/bolt/rotation/TimeBasedRotationPolicy.java
@@ -1,0 +1,68 @@
+package org.apache.storm.hdfs.bolt.rotation;
+
+
+import org.apache.storm.hdfs.common.filemanager.FileManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import backtype.storm.tuple.Tuple;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * File rotation policy that will rotate files after a certain
+ * amount of time has pass
+ *
+ * For example:
+ * <pre>
+ *     // rotate files every 30 minutes
+ *     TimeRotationPolicy policy =
+ *          new TimeRotationPolicy(30.0, Units.MINUTES, FileManager);
+ * </pre>
+ *
+ */
+public class TimeBasedRotationPolicy implements FileRotationPolicy {
+    private static final Logger LOG = LoggerFactory.getLogger(TimeBasedRotationPolicy.class);
+
+    private final int value;
+    private final TimeUnit unit;
+
+    public TimeBasedRotationPolicy(int value, TimeUnit unit) {
+        this.value = value;
+        this.unit = unit;
+    }
+
+    public void prepare (final FileManager fileManager) {
+        new Thread("TimeBasedRotation-timer-thread"){
+            @Override
+            public void run() {
+                while(true) {
+                    try {
+                        Thread.sleep(unit.toMillis(value));
+                        fileManager.rotate();
+                    } catch (Exception e) {
+                        LOG.warn("Failed to rotate the file.", e);
+                    }
+                }
+            }
+        }.start();
+    }
+
+    /**
+     * Always returns false as the rotation happens asynchronously in timer thread.
+     * @param tuple The tuple executed.
+     * @param offset current offset of file being written
+     * @return always false
+     */
+    @Override
+    public boolean mark(Tuple tuple, long offset) {
+        return false;
+    }
+
+    /**
+     *
+     */
+    @Override
+    public void reset() {
+        throw new UnsupportedOperationException("Should never be called");
+    }
+}

--- a/src/main/java/org/apache/storm/hdfs/common/filemanager/AbstractFileManager.java
+++ b/src/main/java/org/apache/storm/hdfs/common/filemanager/AbstractFileManager.java
@@ -1,0 +1,46 @@
+package org.apache.storm.hdfs.common.filemanager;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.storm.hdfs.bolt.format.FileNameFormat;
+import org.apache.storm.hdfs.common.format.CommonFileNameFormat;
+import org.apache.storm.hdfs.common.rotation.RotationAction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class AbstractFileManager implements FileManager {
+    private static final Logger LOG = LoggerFactory.getLogger(SequenceFileManager.class);
+
+    protected CommonFileNameFormat fileNameFormat;
+    protected String fsUrl;
+    protected List<RotationAction> rotationActions = new ArrayList<RotationAction>(1);
+    protected Configuration hdfsConfig;
+    protected long rotation;
+    protected Path currentFile;
+    protected FileSystem fs;
+    protected long offset;
+
+    @Override
+    public synchronized void rotate() throws IOException {
+        LOG.info("Rotating output file...");
+        long start = System.currentTimeMillis();
+        closeOutputFile();
+        this.rotation++;
+
+        Path newFile = createOutputFile();
+        LOG.info("Performing {} file rotation actions.", this.rotationActions.size());
+        for(RotationAction action : this.rotationActions){
+            action.execute(this.fs, this.currentFile);
+        }
+
+        this.currentFile = newFile;
+        this.offset = 0;
+        long time = System.currentTimeMillis() - start;
+        LOG.info("File rotation took {} ms.", time);
+    }
+}

--- a/src/main/java/org/apache/storm/hdfs/common/filemanager/FileManager.java
+++ b/src/main/java/org/apache/storm/hdfs/common/filemanager/FileManager.java
@@ -1,0 +1,21 @@
+package org.apache.storm.hdfs.common.filemanager;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Writable;
+
+import java.io.IOException;
+
+public interface FileManager {
+
+    void closeOutputFile() throws IOException;
+
+    Path createOutputFile() throws IOException;
+
+    long append(byte[] bytes) throws IOException;
+
+    long append(Writable key, Writable val) throws IOException;
+
+    void rotate() throws IOException;
+
+    void sync() throws IOException;
+}

--- a/src/main/java/org/apache/storm/hdfs/common/filemanager/HDFSFileManager.java
+++ b/src/main/java/org/apache/storm/hdfs/common/filemanager/HDFSFileManager.java
@@ -1,0 +1,82 @@
+package org.apache.storm.hdfs.common.filemanager;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.client.HdfsDataOutputStream;
+import org.apache.hadoop.io.Writable;
+import org.apache.storm.hdfs.bolt.format.FileNameFormat;
+import org.apache.storm.hdfs.common.format.CommonFileNameFormat;
+import org.apache.storm.hdfs.common.rotation.RotationAction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.EnumSet;
+
+
+public class HDFSFileManager extends AbstractFileManager {
+    private static final Logger LOG = LoggerFactory.getLogger(SequenceFileManager.class);
+
+    private FSDataOutputStream out;
+
+    @Override
+    public synchronized void closeOutputFile() throws IOException {
+        sync();
+        this.out.close();
+    }
+
+    @Override
+    public synchronized Path createOutputFile() throws IOException {
+        this.currentFile = new Path(this.fileNameFormat.getPath(), this.fileNameFormat.getName(this.rotation, System.currentTimeMillis()));
+        this.out = this.fs.create(currentFile);
+        return currentFile;
+    }
+
+    @Override
+    public synchronized long append(byte[] bytes) throws IOException {
+        out.write(bytes);
+        this.offset += bytes.length;
+        return this.offset;
+    }
+
+    @Override
+    public synchronized long append(Writable key, Writable val) throws IOException {
+        throw new UnsupportedOperationException("Use SequenceFileManager for writing key-> val.");
+    }
+
+    @Override
+    public synchronized void sync() throws IOException {
+        if(this.out instanceof HdfsDataOutputStream){
+            ((HdfsDataOutputStream)this.out).hsync(EnumSet.of(HdfsDataOutputStream.SyncFlag.UPDATE_LENGTH));
+        } else {
+            this.out.hsync();
+        }
+    }
+
+    public HDFSFileManager withFileNameFormat(final CommonFileNameFormat fileNameFormat) {
+        this.fileNameFormat = fileNameFormat;
+        return this;
+    }
+
+    public HDFSFileManager withFsUrl(final String fsUrl) {
+        this.fsUrl = fsUrl;
+        return this;
+    }
+
+    public HDFSFileManager addRotationAction(final RotationAction rotationAction) {
+        this.rotationActions.add(rotationAction);
+        return this;
+    }
+
+    public HDFSFileManager withHdfsConfig(final Configuration hdfsConfig) {
+        this.hdfsConfig = hdfsConfig;
+        return this;
+    }
+
+    public HDFSFileManager withFs(final FileSystem fs) {
+        this.fs = fs;
+        return this;
+    }
+}

--- a/src/main/java/org/apache/storm/hdfs/common/filemanager/SequenceFileManager.java
+++ b/src/main/java/org/apache/storm/hdfs/common/filemanager/SequenceFileManager.java
@@ -1,0 +1,108 @@
+package org.apache.storm.hdfs.common.filemanager;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.compress.CompressionCodecFactory;
+import org.apache.storm.hdfs.bolt.format.FileNameFormat;
+import org.apache.storm.hdfs.bolt.format.SequenceFormat;
+import org.apache.storm.hdfs.common.format.CommonFileNameFormat;
+import org.apache.storm.hdfs.common.format.CommonSequenceFormat;
+import org.apache.storm.hdfs.common.rotation.RotationAction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class SequenceFileManager extends AbstractFileManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SequenceFileManager.class);
+
+    private CommonSequenceFormat format;
+    private SequenceFile.CompressionType compressionType = SequenceFile.CompressionType.RECORD;
+    private SequenceFile.Writer writer;
+    private String compressionCodec = "default";
+    private transient CompressionCodecFactory codecFactory;
+
+    @Override
+    public synchronized Path createOutputFile() throws IOException {
+        this.currentFile = new Path(this.fsUrl + this.fileNameFormat.getPath(), this.fileNameFormat.getName(this.rotation, System.currentTimeMillis()));
+        this.writer = SequenceFile.createWriter(
+                this.hdfsConfig,
+                SequenceFile.Writer.file(currentFile),
+                SequenceFile.Writer.keyClass(this.format.keyClass()),
+                SequenceFile.Writer.valueClass(this.format.valueClass()),
+                SequenceFile.Writer.compression(this.compressionType, this.codecFactory.getCodecByName(this.compressionCodec))
+        );
+        return this.currentFile;
+    }
+
+    @Override
+    public synchronized void closeOutputFile() throws IOException {
+        sync();
+        this.writer.close();
+    }
+
+    @Override
+    public synchronized long append(byte[] bytes) throws IOException {
+        throw new UnsupportedOperationException("SequenceWriter only supports writing key, val pairs");
+    }
+
+    @Override
+    public synchronized long append(Writable key, Writable val) throws IOException {
+        this.writer.append(key, val);
+        return writer.getLength();
+    }
+
+    @Override
+    public synchronized void sync() throws IOException {
+        this.writer.hsync();
+    }
+
+    public SequenceFileManager withFileNameFormat(final CommonFileNameFormat fileNameFormat) {
+        this.fileNameFormat = fileNameFormat;
+        return this;
+    }
+
+    public SequenceFileManager withFsUrl(final String fsUrl) {
+        this.fsUrl = fsUrl;
+        return this;
+    }
+
+    public SequenceFileManager addRotationAction(final RotationAction rotationAction) {
+        this.rotationActions.add(rotationAction);
+        return this;
+    }
+
+    public SequenceFileManager withHdfsConfig(final Configuration hdfsConfig) {
+        this.hdfsConfig = hdfsConfig;
+        return this;
+    }
+
+    public SequenceFileManager withFs(final FileSystem fs) {
+        this.fs = fs;
+        return this;
+    }
+
+    public SequenceFileManager withSequenceFormat(CommonSequenceFormat format) {
+        this.format = format;
+        return this;
+    }
+
+    public SequenceFileManager withCodecFactory(CompressionCodecFactory codecFactory) {
+        this.codecFactory = codecFactory;
+        return this;
+    }
+
+    public SequenceFileManager withCompressionType(SequenceFile.CompressionType compressionType) {
+        this.compressionType = compressionType;
+        return this;
+    }
+
+    public SequenceFileManager withCompressionCodec(String codec) {
+        this.compressionCodec = codec;
+        return this;
+    }
+}

--- a/src/main/java/org/apache/storm/hdfs/common/format/CommonFileNameFormat.java
+++ b/src/main/java/org/apache/storm/hdfs/common/format/CommonFileNameFormat.java
@@ -1,0 +1,16 @@
+package org.apache.storm.hdfs.common.format;
+
+import java.io.Serializable;
+
+public interface CommonFileNameFormat extends Serializable {
+
+    /**
+     * Returns the filename the HdfsBolt will create.
+     * @param rotation the current file rotation number (incremented on every rotation)
+     * @param timeStamp current time in milliseconds when the rotation occurs
+     * @return
+     */
+    String getName(long rotation, long timeStamp);
+
+    String getPath();
+}

--- a/src/main/java/org/apache/storm/hdfs/common/format/CommonSequenceFormat.java
+++ b/src/main/java/org/apache/storm/hdfs/common/format/CommonSequenceFormat.java
@@ -1,0 +1,19 @@
+package org.apache.storm.hdfs.common.format;
+
+
+import java.io.Serializable;
+
+public interface CommonSequenceFormat extends Serializable {
+    /**
+     * Key class used by implementation (e.g. IntWritable.class, etc.)
+     *
+     * @return
+     */
+    Class keyClass();
+
+    /**
+     * Value class used by implementation (e.g. Text.class, etc.)
+     * @return
+     */
+    Class valueClass();
+}

--- a/src/main/java/org/apache/storm/hdfs/trident/format/FileNameFormat.java
+++ b/src/main/java/org/apache/storm/hdfs/trident/format/FileNameFormat.java
@@ -17,6 +17,8 @@
  */
 package org.apache.storm.hdfs.trident.format;
 
+import org.apache.storm.hdfs.common.format.CommonFileNameFormat;
+
 import java.io.Serializable;
 import java.util.Map;
 
@@ -24,17 +26,8 @@ import java.util.Map;
  * Formatter interface for determining HDFS file names.
  *
  */
-public interface FileNameFormat extends Serializable {
+public interface FileNameFormat extends CommonFileNameFormat {
 
     void prepare(Map conf, int partitionIndex, int numPartitions);
 
-    /**
-     * Returns the filename the HdfsBolt will create.
-     * @param rotation the current file rotation number (incremented on every rotation)
-     * @param timeStamp current time in milliseconds when the rotation occurs
-     * @return
-     */
-    String getName(long rotation, long timeStamp);
-
-    String getPath();
 }

--- a/src/main/java/org/apache/storm/hdfs/trident/format/SequenceFormat.java
+++ b/src/main/java/org/apache/storm/hdfs/trident/format/SequenceFormat.java
@@ -1,6 +1,7 @@
 package org.apache.storm.hdfs.trident.format;
 
 import org.apache.hadoop.io.Writable;
+import org.apache.storm.hdfs.common.format.CommonSequenceFormat;
 import storm.trident.tuple.TridentTuple;
 
 import java.io.Serializable;
@@ -9,19 +10,7 @@ import java.io.Serializable;
  * Interface for converting <code>TridentTuple</code> objects to HDFS sequence file key-value pairs.
  *
  */
-public interface SequenceFormat extends Serializable {
-    /**
-     * Key class used by implementation (e.g. IntWritable.class, etc.)
-     *
-     * @return
-     */
-    Class keyClass();
-
-    /**
-     * Value class used by implementation (e.g. Text.class, etc.)
-     * @return
-     */
-    Class valueClass();
+public interface SequenceFormat extends CommonSequenceFormat {
 
     /**
      * Given a tuple, return the key that should be written to the sequence file.

--- a/src/main/java/org/apache/storm/hdfs/trident/rotation/TimeBasedRotationPolicy.java
+++ b/src/main/java/org/apache/storm/hdfs/trident/rotation/TimeBasedRotationPolicy.java
@@ -1,0 +1,70 @@
+package org.apache.storm.hdfs.trident.rotation;
+
+
+import backtype.storm.tuple.Tuple;
+import org.apache.storm.hdfs.trident.rotation.FileRotationPolicy;
+import org.apache.storm.hdfs.common.filemanager.FileManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import storm.trident.tuple.TridentTuple;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * File rotation policy that will rotate files after a certain
+ * amount of time has pass
+ *
+ * For example:
+ * <pre>
+ *     // rotate files every 30 minutes
+ *     TimeRotationPolicy policy =
+ *          new TimeRotationPolicy(30.0, Units.MINUTES, FileManager);
+ * </pre>
+ *
+ */
+public class TimeBasedRotationPolicy implements FileRotationPolicy {
+    private static final Logger LOG = LoggerFactory.getLogger(TimeBasedRotationPolicy.class);
+
+    private final int value;
+    private final TimeUnit unit;
+
+    public TimeBasedRotationPolicy(int value, TimeUnit unit) {
+        this.value = value;
+        this.unit = unit;
+    }
+
+    public void prepare (final FileManager fileManager) {
+        new Thread("TimeBasedRotation-timer-thread"){
+            @Override
+            public void run() {
+                while(true) {
+                    try {
+                        Thread.sleep(unit.toMillis(value));
+                        fileManager.rotate();
+                    } catch (Exception e) {
+                        LOG.warn("Failed to rotate the file.", e);
+                    }
+                }
+            }
+        }.start();
+    }
+
+    /**
+     * Always returns false as the rotation happens asynchronously in timer thread.
+     * @param tuple The tuple executed.
+     * @param offset current offset of file being written
+     * @return always false
+     */
+    @Override
+    public boolean mark(TridentTuple tuple, long offset) {
+        return false;
+    }
+
+    /**
+     *
+     */
+    @Override
+    public void reset() {
+        throw new UnsupportedOperationException("Should never be called");
+    }
+}


### PR DESCRIPTION
...ting operations to avoid leaking the bolt objects and to avoid duplicating the code between trident and pure storm.

Would probably refactor more in next iteration to ensure the client can build the file manager and pass it as part of bolt object creation which should allow them to do both unit test and integ test with local file system.
Tested with pseudo distributed HDFS on my box for existing rotation policy and with TimeBased Rotation policy.
