### PR TITLE
ensuring the existence of keytab file before passing to Hadoop

### DIFF
--- a/src/main/java/org/apache/storm/hdfs/common/security/HdfsSecurityUtil.java
+++ b/src/main/java/org/apache/storm/hdfs/common/security/HdfsSecurityUtil.java
@@ -33,15 +33,12 @@ public class HdfsSecurityUtil {
     public static final String STORM_USER_NAME_KEY = "hdfs.kerberos.principal";
 
     public static void login(Map conf, Configuration hdfsConfig) throws IOException {
-        if (UserGroupInformation.isSecurityEnabled()) {
-            String keytab = (String) conf.get(STORM_KEYTAB_FILE_KEY);
-            if (keytab != null) {
-              hdfsConfig.set(STORM_KEYTAB_FILE_KEY, keytab);
-            }
-            String userName = (String) conf.get(STORM_USER_NAME_KEY);
-            if (userName != null) {
-              hdfsConfig.set(STORM_USER_NAME_KEY, userName);
-            }
+        String keytab = (String) conf.get(STORM_KEYTAB_FILE_KEY);
+        String userName = (String) conf.get(STORM_USER_NAME_KEY);
+
+        if (UserGroupInformation.isSecurityEnabled() && keytab != null && userName != null) {
+            hdfsConfig.set(STORM_KEYTAB_FILE_KEY, keytab);
+            hdfsConfig.set(STORM_USER_NAME_KEY, userName);
             SecurityUtil.login(hdfsConfig, STORM_KEYTAB_FILE_KEY, STORM_USER_NAME_KEY);
         }
     }


### PR DESCRIPTION
Storm now offers the ability to use forwardable, renewable tickets to
authenticate to Hadoop. This commit makes it possible to use these
tickets rather than fixed keytab files, which are not ideal for
Kerberos principals representing end users.
